### PR TITLE
Phase mask correction

### DIFF
--- a/exc1.x.f90
+++ b/exc1.x.f90
@@ -54,15 +54,15 @@ subroutine get_single_excitation(det1,det2,exc,phase,Nint)
        low  = min(exc(1,1,ispin),exc(1,2,ispin))
        high = max(exc(1,1,ispin),exc(1,2,ispin))
        j = ishft(low-1,-6)+1
-       n = iand(low,63)
+       n = iand(low-1,63)
        k = ishft(high-1,-6)+1
-       m = iand(high,63)
+       m = iand(high-1,63)
        if (j==k) then
          nperm = popcnt(iand(det1(j,ispin), &
-            iand( ibset(0_8,m-1)-1_8, ibclr(-1_8,n)+1_8 ) ))
+            iand( not(ishft(1_8,n+1))+1_8 ,ishft(1_8,m)-1_8)))
        else
-         nperm = popcnt(iand(det1(k,ispin), ibset(0_8,m-1)-1_8)) + &
-                 popcnt(iand(det1(j,ispin), ibclr(-1_8,n) +1_8))
+         nperm = popcnt(iand(det1(k,ispin), ishft(1_8,m)-1_8)) + &
+                 popcnt(iand(det1(j,ispin), not(ishft(1_8,n+1))+1_8))
          do i=j+1,k-1
            nperm = nperm + popcnt(det1(i,ispin))
          end do

--- a/exc2.x.f90
+++ b/exc2.x.f90
@@ -72,12 +72,12 @@ subroutine get_double_excitation(det1,det2,exc,phase,Nint)
     m = iand(high,63)
     if (j==k) then
       nperm = nperm + popcnt(iand(det1(j,ispin),  &
-         iand( ibset(0_8,m-1)-1_8, ibclr(-1_8,n)+1_8 ) ))
+         iand( not(ishft(1_8,n+1))+1 ,ishft(1_8,m)-1)))
     else
       nperm = nperm + popcnt(iand(det1(k,ispin),  & 
-                             ibset(0_8,m-1)-1_8)) &
+                             ishft(1_8,m)-1)) &
                     + popcnt(iand(det1(j,ispin),  &
-                             ibclr(-1_8,n) +1_8))
+                             not(ishft(1_8,n+1))+1))
       do l=j+1,k-1
         nperm = nperm + popcnt(det1(l,ispin))
       end do

--- a/exc2.x.f90
+++ b/exc2.x.f90
@@ -67,9 +67,9 @@ subroutine get_double_excitation(det1,det2,exc,phase,Nint)
     low  = min(exc(i,1,ispin),exc(i,2,ispin))
     high = max(exc(i,1,ispin),exc(i,2,ispin))
     j = ishft(low-1,-6)+1
-    n = iand(low,63)
+    n = iand(low-1,63)
     k = ishft(high-1,-6)+1
-    m = iand(high,63)
+    m = iand(high-1,63)
     if (j==k) then
       nperm = nperm + popcnt(iand(det1(j,ispin),  &
          iand( not(ishft(1_8,n+1))+1 ,ishft(1_8,m)-1)))

--- a/main/test.f90
+++ b/main/test.f90
@@ -172,7 +172,7 @@
     call cpu_time(cpu1)
     print *,  'Cycles density matrix : ', (t1-t0)/(ndet*(ndet-1)/2)
     print *,  'CPU    density matrix : ', cpu1-cpu0
-!   print *, (density_matrix(k,k), k=1,mo_num)
+   !print *, (density_matrix(k,k), k=1,mo_num)
 
   end !----------
 


### PR DESCRIPTION
Here are the changes to the phase mask. I used shifts in order to compute 2^(n+1) and 2^m, it should be similar to the algorithm 4 in the paper.

Original code acutally gave different answers when det1 and det2 are switched around. Tested this fix on our code with 500 orbitals and 1,000,000+ csfs and gives exact answers to our original slater-rule code but way faster so it looks all good :)

